### PR TITLE
Fix tests that got broken after releasing Ansible 2.5.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ services:
   - docker
 
 install:
-  - sudo pip install ansible==2.5.0
+  - sudo pip install ansible==2.4.3
   - curl -LSs https://raw.githubusercontent.com/BR0kEN-/cikit/master/install.sh | sudo bash -s -- --no-requirements-check
   - cd /usr/local/share/cikit/
   - sudo git pull origin ${CIKIT_BRANCH} --recurse-submodules

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ services:
   - docker
 
 install:
-  - sudo pip install ansible
+  - sudo pip install ansible==2.5.0
   - curl -LSs https://raw.githubusercontent.com/BR0kEN-/cikit/master/install.sh | sudo bash -s -- --no-requirements-check
   - cd /usr/local/share/cikit/
   - sudo git pull origin ${CIKIT_BRANCH} --recurse-submodules

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ python:
 env:
   # @todo Change for "master" when https://github.com/BR0kEN-/cikit/pull/107 will be merged.
   CIKIT_BRANCH: issues/106
+  ANSIBLE_VERBOSITY: 2
 
 services:
   - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,8 @@ services:
   - docker
 
 install:
-  - sudo pip install ansible==2.4.3
+  # @todo See lib/variables.py
+  - sudo pip install ansible==2.5.0
   - curl -LSs https://raw.githubusercontent.com/BR0kEN-/cikit/master/install.sh | sudo bash -s -- --no-requirements-check
   - cd /usr/local/share/cikit/
   - sudo git pull origin ${CIKIT_BRANCH} --recurse-submodules

--- a/start.sh
+++ b/start.sh
@@ -4,10 +4,10 @@ set -e
 cd /usr/local/share/cikit/matrix/roles/api/files/cikit-rest-api
 
 cikit env/start --ignore-cikit-mount --privileged
-cikit ssh "apt install ssh lxc iptables -y"
-cikit matrix/provision --rest-api
-cikit ssh "bash -c 'service docker start && systemctl enable docker'"
-
-if [ "test" == "$1" ]; then
-  cikit ssh "bash -c 'cd /var/www/cikit-rest-api && npm run lint && npm test'"
-fi
+#cikit ssh "apt install ssh lxc iptables -y"
+#cikit matrix/provision --rest-api
+#cikit ssh "bash -c 'service docker start && systemctl enable docker'"
+#
+#if [ "test" == "$1" ]; then
+#  cikit ssh "bash -c 'cd /var/www/cikit-rest-api && npm run lint && npm test'"
+#fi

--- a/start.sh
+++ b/start.sh
@@ -4,10 +4,10 @@ set -e
 cd /usr/local/share/cikit/matrix/roles/api/files/cikit-rest-api
 
 cikit env/start --ignore-cikit-mount --privileged
-#cikit ssh "apt install ssh lxc iptables -y"
-#cikit matrix/provision --rest-api
-#cikit ssh "bash -c 'service docker start && systemctl enable docker'"
-#
-#if [ "test" == "$1" ]; then
-#  cikit ssh "bash -c 'cd /var/www/cikit-rest-api && npm run lint && npm test'"
-#fi
+cikit ssh "apt install ssh lxc iptables -y"
+cikit matrix/provision --rest-api
+cikit ssh "bash -c 'service docker start && systemctl enable docker'"
+
+if [ "test" == "$1" ]; then
+  cikit ssh "bash -c 'cd /var/www/cikit-rest-api && npm run lint && npm test'"
+fi


### PR DESCRIPTION
Ansible 2.5.1 introduced undocumented changes that simply broke the whole implementation:

- [ ] https://github.com/ansible/ansible/issues/39007
- [x] https://github.com/ansible/ansible/issues/39014

The `2.5.0` should be removed once issues will be resolved.